### PR TITLE
Remove no longer needed doctests options

### DIFF
--- a/tests/doctests.hs
+++ b/tests/doctests.hs
@@ -10,13 +10,7 @@ import Control.Applicative
 main :: IO ()
 main = do
     sources <- findSources
-    doctest $
-        [ "-isrc"
-        , "-idist/build/autogen"
-        , "-optP-include"
-        , "-optPdist/build/autogen/cabal_macros.h"
-        ]
-        ++ sources
+    doctest sources
 
 findSources :: IO [FilePath]
 findSources = filter (isSuffixOf ".hs") <$> go "src"


### PR DESCRIPTION
This makes tests work with Stack and `cabal new-test`:
```
qrilka@qdesktop ~/ws/h/lens-regex $ cabal new-test
Build profile: -w ghc-8.4.4 -O1
In order, the following will be built (use -v for more details):
 - lens-regex-0.1.0 (test:doctests) (file tests/doctests.hs changed)
Preprocessing test suite 'doctests' for lens-regex-0.1.0..
Building test suite 'doctests' for lens-regex-0.1.0..
[1 of 1] Compiling Main             ( tests/doctests.hs, /home/qrilka/ws/h/lens-regex/dist-newstyle/build/x86_64-linux/ghc-8.4.4/lens-regex-0.1.0/t/doctests/build/doctests/doctests-tmp/Main.o )
Linking /home/qrilka/ws/h/lens-regex/dist-newstyle/build/x86_64-linux/ghc-8.4.4/lens-regex-0.1.0/t/doctests/build/doctests/doctests ...
Running 1 test suites...
Test suite doctests: RUNNING...
Loaded package environment from /home/qrilka/ws/h/lens-regex/.ghc.environment.x86_64-linux-8.4.4
Loaded package environment from /home/qrilka/ws/h/lens-regex/.ghc.environment.x86_64-linux-8.4.4
Examples: 12  Tried: 12  Errors: 0  Failures: 0
Test suite doctests: PASS
Test suite logged to:
/home/qrilka/ws/h/lens-regex/dist-newstyle/build/x86_64-linux/ghc-8.4.4/lens-regex-0.1.0/t/doctests/test/lens-regex-0.1.0-doctests.log
1 of 1 test suites (1 of 1 test cases) passed.
qrilka@qdesktop ~/ws/h/lens-regex $ stack test
lens-regex-0.1.0: unregistering (local file changes: tests/doctests.hs)
lens-regex-0.1.0: configure (lib + test)
Configuring lens-regex-0.1.0...
Warning: Packages using 'cabal-version: >= 1.10' must specify the
'default-language' field for each component (e.g. Haskell98 or Haskell2010).
If a component uses different languages in different modules then list the
other ones in the 'other-languages' field.
lens-regex-0.1.0: build (lib + test)
Preprocessing test suite 'doctests' for lens-regex-0.1.0..
Building test suite 'doctests' for lens-regex-0.1.0..
[1 of 1] Compiling Main             ( tests/doctests.hs, .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/doctests/doctests-tmp/Main.o )
Linking .stack-work/dist/x86_64-linux-tinfo6/Cabal-2.4.0.1/build/doctests/doctests ...
Preprocessing library for lens-regex-0.1.0..
Building library for lens-regex-0.1.0..
lens-regex-0.1.0: copy/register
Installing library in /home/qrilka/ws/h/lens-regex/.stack-work/install/x86_64-linux-tinfo6/lts-13.0/8.6.3/lib/x86_64-linux-ghc-8.6.3/lens-regex-0.1.0-5DqR4oUp708KeHzssXzCUP
Registering library for lens-regex-0.1.0..
lens-regex-0.1.0: test (suite: doctests)
            
Examples: 12  Tried: 12  Errors: 0  Failures: 0ed: 0  Errors: 0  Failures: 0                                                            
lens-regex-0.1.0: Test suite doctests passed
Completed 2 action(s).        

```