### PR TITLE
Relax upper bound version restrictions on lens dependency.

### DIFF
--- a/lens-regex.cabal
+++ b/lens-regex.cabal
@@ -1,5 +1,5 @@
 name:                lens-regex
-version:             0.1.1
+version:             0.1.2
 synopsis:            Lens powered regular expression
 description:         lens interface for regex-base. Please see the README on Github at <https://github.com/himura/lens-regex#readme>
 homepage:            https://github.com/himura/lens-regex

--- a/lens-regex.cabal
+++ b/lens-regex.cabal
@@ -34,7 +34,7 @@ library
                        Text.Regex.Quote
   build-depends:       base >= 4.5 && < 5
                      , array
-                     , lens >= 4 && < 5
+                     , lens >= 4
                      , regex-base
                      , template-haskell
   hs-source-dirs:      src


### PR DESCRIPTION
related issue: https://github.com/commercialhaskell/stackage/issues/5874